### PR TITLE
Remove unnecessary line breaks from API reference index

### DIFF
--- a/apireference/README.md
+++ b/apireference/README.md
@@ -1,12 +1,5 @@
 # The Microsoft Edge API Surface
 
-Microsoft Edge provides support for over 4300 standards-based open web APIs.
-Additionally, Microsoft Edge is part of the larger Universal Windows
-Platform (UWP) that powers [Windows apps using JavaScript and HTML](https://msdn.microsoft.com/library/windows/apps/mt280216.aspx) and
-also the [HTML](https://msdn.microsoft.com/en-us/library/windows/apps/dn301831.aspx) and  [XAML](https://msdn.microsoft.com/en-us/library/windows/apps/windows.ui.xaml.controls.webview)
-versions of the UWP WebView control. The Microsoft Edge API surface thus also includes
-specific features for building Windows apps.
+Microsoft Edge provides support for over 4300 standards-based open web APIs. Additionally, Microsoft Edge is part of the larger Universal Windows Platform (UWP) that powers [Windows apps using JavaScript and HTML](https://msdn.microsoft.com/library/windows/apps/mt280216.aspx) and also the [HTML](https://msdn.microsoft.com/en-us/library/windows/apps/dn301831.aspx) and [XAML](https://msdn.microsoft.com/en-us/library/windows/apps/windows.ui.xaml.controls.webview) versions of the UWP WebView control. The Microsoft Edge API surface thus also includes specific features for building Windows apps.
 
-Here you'll find an index of the APIs currently supported in Microsoft Edge, as well
-as new APIs only available in the latest [Windows Insider](https://insider.windows.com/) preview
-builds. Supported interfaces are described using the *Web Interface Definition Language*, [Web IDL](https://en.wikipedia.org/wiki/Web_IDL).
+Here you'll find an index of the APIs currently supported in Microsoft Edge, as well as new APIs only available in the latest [Windows Insider](https://insider.windows.com/) preview builds. Supported interfaces are described using the *Web Interface Definition Language*, [Web IDL](https://en.wikipedia.org/wiki/Web_IDL).


### PR DESCRIPTION
I noticed while on the live site that this page had some weird line breaks in it. Seems that it was caused by hard returns instead of soft wrapping text in someone's editor.